### PR TITLE
Issue in IMRX plot generation

### DIFF
--- a/pyspc/ccharts/imrx.py
+++ b/pyspc/ccharts/imrx.py
@@ -29,7 +29,7 @@ class imrx(ccharts):
 
     def plot(self, data, size, newdata=None):
 
-        sizes, data = data.T
+        sizes, data = [i for i in range(len(data))], data.T
         if self.size == 1:
             sizes, data = data, sizes
 


### PR DESCRIPTION
As written in the code that to generate imrx plot, it creates a dictionary for the further processing, So even when we transpose the we do not get the Key values for the dictionary where we use sizes for the keys of the dictionary, so the proposes change in the line 32 will be a solution for the problem.